### PR TITLE
Feature/use proptypes from package

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var PropTypes = require('prop-types');
+
 var React = require('react')
 var assign = require('object-assign')
 
@@ -10,7 +12,7 @@ module.exports = React.createClass({
     displayName: 'ReactRadioGroup',
 
     propTypes: {
-        name: React.PropTypes.string.isRequired,
+        name: PropTypes.string.isRequired,
         items: function(props, name){
             if (!props.children && !props.items){
                 return new Error('Your component has no children. In this case, you should specify an items array.')

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "webpack-dev-server": "^1.6.6"
   },
   "dependencies": {
-    "object-assign": "^2.0.0"
+    "object-assign": "^2.0.0",
+    "prop-types": "^15.6.0"
   },
   "peerDependencies": {
     "react": ">=0.13.0 || >=0.14.0-rc1"


### PR DESCRIPTION
# What does this PR do? 

Remove react warnings when you're using `propTypes` from the `React` package based on the  [migration guide](https://reactjs.org/blog/2017/04/07/react-v15.5.0.html#migrating-from-reactproptypes). 

With this update, we can migrate easier to the react latest version. 

